### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Crowd-sourced hammock locations.
 
 While this app isn't really here to be contributed to (though I wouldn't mind contributions!) you can build and run it yourself if you'd like. 
 
-All you need to do is download or clone the project, open in Xcode 7.3, and run it. Cocoapods are checked into the repo on purpose, and you shouldn't need to run `pod install` before running the app. 
+All you need to do is download or clone the project, open in Xcode 7.3, and run it. CocoaPods are checked into the repo on purpose, and you shouldn't need to run `pod install` before running the app. 
 
 ## More!
 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
